### PR TITLE
[WORKFLOWS-447] Create Dockerfile for `sagetasks`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,13 +1,3 @@
-# ignore .git and .cache folders
-.git
-.cache
-
-# ignore all markdown files (md) beside README.md
-*.md
-!README.md
-
-# gitignore
-
 # Temporary and binary files
 *~
 *.py[cod]

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,65 @@
+# ignore .git and .cache folders
+.git
+.cache
+
+# ignore all markdown files (md) beside README.md
+*.md
+!README.md
+
+# gitignore
+
+# Temporary and binary files
+*~
+*.py[cod]
+*.so
+*.cfg
+!.isort.cfg
+!setup.cfg
+*.orig
+*.log
+*.pot
+__pycache__/*
+.cache/*
+.*.swp
+*/.ipynb_checkpoints/*
+.DS_Store
+
+# Project files
+.ropeproject
+.project
+.pydevproject
+.settings
+.idea
+.vscode
+tags
+.env
+
+# Package files
+*.egg
+*.eggs/
+.installed.cfg
+*.egg-info
+
+# Unittest and coverage
+htmlcov/*
+.coverage
+.coverage.*
+.tox
+junit*.xml
+coverage.xml
+.pytest_cache/
+
+# Build and docs folder/files
+build/*
+dist/*
+sdist/*
+docs/api/*
+docs/_rst/*
+docs/_build/*
+cover/*
+MANIFEST
+
+# Per-project virtualenvs
+.venv*/
+.conda*/
+.python-version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # GitHub Actions configuration
 # Reference: https://docs.github.com/en/actions
 
-name: tests
+name: Test Python package and publish releases
 
 on:
   push:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,39 @@
+# This workflow builds and pushes the docker image using docker's v2 action
+# which requires explicitly setting up buildx and logging in
+
+name: Build and publish container to Docker Hub
+
+on:
+  push:
+    tags: ['v[0-9]*', '[0-9]+.[0-9]+*']  # Match tags that resemble a version
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_ORG:  sagebionetworks
+      DOCKER_REPO: sagetasks
+      DOCKER_TAG:  ${{ github.ref_name }}
+    steps:
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.DOCKER_ORG }}/{{ env.DOCKER_REPO }}:latest
+            ${{ env.DOCKER_ORG }}/{{ env.DOCKER_REPO }}:{{ env.DOCKER_TAG }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,6 @@
 # Simple workflow for deploying static content to GitHub Pages
-name: Deploy static content to Pages
+
+name: Deploy Sphinx docs to GitHub Pages
 
 on:
   # Runs on pushes targeting the default branch

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.10.6
+
+WORKDIR /usr/src/app
+
+ARG PSEUDO_VERSION=1
+
+COPY . .
+
+RUN pip install --no-cache-dir pipenv
+
+RUN SETUPTOOLS_SCM_PRETEND_VERSION=${PSEUDO_VERSION} \
+	pipenv install --system
+
+CMD [ "python", "-c", "import sagetasks" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,15 @@ WORKDIR /usr/src/app
 
 ARG PSEUDO_VERSION=1
 
-COPY . .
-
 RUN pip install --no-cache-dir pipenv
 
-RUN SETUPTOOLS_SCM_PRETEND_VERSION=${PSEUDO_VERSION} \
-	pipenv install --system
+COPY setup.* Pipfile* ./
+COPY src ./src/
+
+RUN SETUPTOOLS_SCM_PRETEND_VERSION_FOR_SAGETASKS=${PSEUDO_VERSION} \
+    pipenv install --system
+
+RUN --mount=source=.git,target=.git,type=bind \
+    pipenv install --system
 
 CMD [ "python", "-c", "import sagetasks" ]


### PR DESCRIPTION
I'm re-using `Pipfile.lock` to create a containerized Python environment with sagetasks installed. Because the package version is inferred from the Git metadata, I had to fiddle with the `pipenv install` command based on [these instructions](https://pypi.org/project/setuptools-scm/#:~:text=volatile%20data%20there.-,Usage%20from%20Docker,-By%20default%2C%20docker). 